### PR TITLE
Fixed typo in error logging when targetTemp=null

### DIFF
--- a/main.js
+++ b/main.js
@@ -149,7 +149,7 @@ function startAdapter(options) {
                                     })
                                     .catch(errorHandler);
                                 }
-                                else{adapter-log.error('no data in targettemp for setting mode')}
+                                else{adapter.log.error('no data in targettemp for setting mode')}
         
                             });
                         } else if (state.val === 1) {


### PR DESCRIPTION
Currently, setting targetTemp=null (for example by mistake in a script) crashes the adapter because of a small typo in the logging code:

![image](https://user-images.githubusercontent.com/972581/101481659-cd0b3800-3955-11eb-9455-bdcdac312186.png)
