### PR TITLE
support on-demand updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ The devices are detected automatically during startup of fritzdect instance. If 
 
 Several permissions have to be set in the fritzbox in order to interact with the adapter!
 
+If the polling interval is set to 0 in the adapter configuration, automatic cyclic polling is disabled and updates are performed only on demand (via the `update` command).
+
 A german explanatory doc is available here: [install_de](./docs/de/install.md)
 
 The widget requires that also vis-metro and vis-jqui-mfd are installed
@@ -182,6 +184,23 @@ Furthermore for energy the array values are summed up for:
 |--------|-------|:-:|--------|
 |active|boolean|x|toggle switch for routine activation|
 
+## Manual Update
+It is possible to trigger a manual update, for example between polling intervals or when polling is disabled.
+To do this, send a message with the text "update" and no parameters to the adapter instance.
+The optional callback will be executed once the update is complete.
+
+Below is an example demonstrating how to trigger the manual update:
+```javascript
+sendTo('fritzdect.0', 'update', null,
+    (e) => {
+        if (e["result"]) {
+            // update successful
+        } else {
+            console.log(e["error"]);
+        }
+    }
+);
+```
 
 ## API limitations
 * Boost and WindowOpen can only be set for the next 24h. time=0 is cancelling the command

--- a/docs/de/install.md
+++ b/docs/de/install.md
@@ -16,6 +16,7 @@ Falls es Probleme gibt, dann eventuell erstmal ein kürzeres und einfaches PW ne
 
 * IP mit vorangestellten "http://" eingeben
 * Polling Intervall kann beliebig gewählt werden (Voreinstellung 5min=300sec). Dies ist notwendig um Bedienung ausserhalb von ioBroker nachzuführen, da die FritzBox keine automatischen Updates liefert.
+* Wird das Polling Intervall auf 0 gesetzt, werden keine zyklischen Abfragen durchgeführt. Updates erfolgen dann ausschließlich auf Abruf (siehe Manuelles Update).
 
 
 ## Adapter Start
@@ -49,6 +50,26 @@ Bei der Vorwahl von 0-AUTO wird die letzte Solltemperatur angewählt.
 Es besteht die Möglichkeit die gemessene Temperatur in der FritzBox zu korrigieren, dazu gibt man die gemessene Temperatur an und es ergibt sich ein Offset. Dieser Offset wird für den Datenpunkt .temp mit berücksichtigt. Hier erhält man also die interne Temperaturmessung.
 Die intern im Heizkörperregler benutzte Ist-Temperatur (actualtemp), wird durch den Offset auch verändert. D.h. der HKR regelt intern auf den korrigierten Wert.
 Vergleichbar für den Soll-/Istverlaufs ist demnach atualtemp und targettemp.
+
+## Manuelles Update
+
+Es ist möglich, ein manuelles Update anzustoßen, zum Beispiel zwischen den Polling-Intervallen oder wenn das Polling deaktiviert ist.
+Dazu senden Sie eine Nachricht mit dem Text "update" und ohne Parameter an die Adapter-Instanz.
+Der optionale Callback wird aufgerufen, wenn das Update abgeschlossen ist.
+
+Unten finden Sie ein Beispiel, das zeigt, wie das manuelle Update ausgelöst wird:
+
+```javascript
+sendTo('fritzdect.0', 'update', null,
+    (e) => {
+        if (e["result"]) {
+            // Update erfolgreich
+        } else {
+            console.log(e["error"]);
+        }
+    }
+);
+```
 
 ## Troubleshooting
 

--- a/main.js
+++ b/main.js
@@ -138,6 +138,7 @@ class Fritzdect extends utils.Adapter {
 		this.boosttime = 5;
 		this.windowtime = 5;
 		this.tsolldefault = 23;
+		this.updatePromise = null;
 	}
 
 	/**
@@ -1279,6 +1280,16 @@ class Fritzdect extends utils.Adapter {
 	}
 
 	async update() {
+		if (!this.updatePromise) {
+			this.updatePromise = this._update()
+				.finally(() => {
+					this.updatePromise = null;
+				});
+		}
+		return this.updatePromise;
+	}
+
+	async _update() {
 		await this.updateDevices(this.fritz).catch((e) => this.errorHandlerAdapter(e));
 		if (!settings.exclude_routines) {
 			await this.updateRoutines(this.fritz).catch((e) =>

--- a/main.js
+++ b/main.js
@@ -1572,27 +1572,27 @@ class Fritzdect extends utils.Adapter {
 		this.log.debug('======================================');
 		this.log.debug('With ' + ident + ' got the following device/group to parse ' + JSON.stringify(array));
 		try {
-			Object.entries(array).forEach(async ([ key, value ]) => {
+			await Promise.all( Object.entries(array).map(async ([ key, value ]) => {
 				if (Array.isArray(value)) {
 					this.log.debug('processing datapoint ' + key + ' as array');
-					value.forEach(async (subarray) => {
+					await Promise.all( value.map(async (subarray) => {
 						//subarray.identifier = subarray.identifier.replace(/\s/g, '');
 						await this.updateData(
 							subarray,
 							ident + '.' + key + '.' + subarray.identifier.replace(/\s/g, '')
 						); // hier wirds erst schwierig wenn array in array
-					});
+					}));
 				} else if (typeof value === 'object' && value !== null) {
 					this.log.debug('processing datapoint ' + key + ' as object');
-					Object.entries(value).forEach(async ([ key2, value2 ]) => {
+					await Promise.all( Object.entries(value).map(async ([ key2, value2 ]) => {
 						this.log.debug(' object transfer ' + key2 + '  ' + value2 + '  ' + ident);
 						await this.updateDatapoint(key2, value2, ident);
-					});
+					}));
 				} else {
 					this.log.debug('processing datapoint ' + key + ' directly');
 					await this.updateDatapoint(key, value, ident);
 				}
-			});
+			}));
 		} catch (e) {
 			this.log.debug(' issue in updateData ' + e);
 			throw {


### PR DESCRIPTION
This PR enables on-demand update mode to avoid continuous polling and guarantee safe, consistent status retrieval exactly when needed.

For example, for a warning about open windows when leaving the apartment, you would otherwise need to set a very short polling interval, which unnecessarily increases the load on the ioBroker server.